### PR TITLE
Spotifyから歌手名を取得できるようにする

### DIFF
--- a/backend/app/controllers/admin/users_controller.rb
+++ b/backend/app/controllers/admin/users_controller.rb
@@ -11,6 +11,8 @@ class Admin::UsersController < Admin::Base
     @user = User.new
   end
 
+  def edit; end
+
   def create
     @user = User.new(user_params)
     if @user.save
@@ -19,8 +21,6 @@ class Admin::UsersController < Admin::Base
       render :new, :unprocessable_entity
     end
   end
-
-  def edit; end
 
   def update
     if @user.update(user_params)

--- a/backend/app/helpers/breadcrumbs_helper.rb
+++ b/backend/app/helpers/breadcrumbs_helper.rb
@@ -34,7 +34,7 @@ module BreadcrumbsHelper
        'admin/videos/comments#edit'],
       ['admin/homes#show', 'admin/videos#index', 'admin/videos#show',
        'admin/videos/comments#index', 'admin/videos/comments#new'],
-       ['admin/homes#show', 'admin/users#index', 'admin/users#new'],
+      ['admin/homes#show', 'admin/users#index', 'admin/users#new'],
       ['admin/homes#show', 'admin/users#index', 'admin/users#show', 'admin/users#edit']
     ]
   end

--- a/backend/app/models/concerns/song_live.rb
+++ b/backend/app/models/concerns/song_live.rb
@@ -72,4 +72,13 @@ module SongLive
     # SongItemsが見つからなかったらここに来る
     []
   end
+
+  def self.update_songs_author_from_spotify!
+    token = Spotify.get_token
+    where(status: %w[song_items_created spotify_fetched]).each do |video|
+      video.update!(status: 'spotify_fetched')
+      video.song_items.update_author_from_spotify!(token)
+      video.update!(status: 'completed') if (video.song_items.completed.count == video.song_items.count)
+    end
+  end
 end

--- a/backend/app/models/concerns/song_live.rb
+++ b/backend/app/models/concerns/song_live.rb
@@ -73,12 +73,19 @@ module SongLive
     []
   end
 
+  def update_songs_author_from_spotify!(spotify_token=nil)
+    spotify_token ||= Spotify.get_token
+    video.update!(status: 'spotify_fetched')
+    where(latest_diff_id: SongDiff.where(author: [nil, ""])).each do |song_item|
+      song_item.update_author_from_spotify!(spotify_token)
+    end
+    update!(status: 'completed') if (video.song_items.completed.count == video.song_items.count)
+  end
+
   def self.update_songs_author_from_spotify!
     token = Spotify.get_token
     where(status: %w[song_items_created spotify_fetched]).each do |video|
-      video.update!(status: 'spotify_fetched')
-      video.song_items.update_author_from_spotify!(token)
-      video.update!(status: 'completed') if (video.song_items.completed.count == video.song_items.count)
+      video.update_author_from_spotify!(token)
     end
   end
 end

--- a/backend/app/models/concerns/song_live.rb
+++ b/backend/app/models/concerns/song_live.rb
@@ -7,8 +7,8 @@ module SongLive
     end
 
     def search_and_create_song_items!
-      where.not(status: %w[song_items_created spotify_fetched completed])\
-        .order(published_at: :desc).all.each(&:search_and_create_song_items!)
+      where.not(status: %w[song_items_created spotify_fetched completed]) \
+           .order(published_at: :desc).all.each(&:search_and_create_song_items!)
     end
   end
 
@@ -73,13 +73,13 @@ module SongLive
     []
   end
 
-  def update_songs_author_from_spotify!(spotify_token=nil)
+  def update_songs_author_from_spotify!(spotify_token = nil)
     spotify_token ||= Spotify.get_token
     update!(status: 'spotify_fetched')
-    song_items.where(latest_diff_id: SongDiff.where(author: [nil, ""])).each do |song_item|
+    song_items.where(latest_diff_id: SongDiff.where(author: [nil, ''])).find_each do |song_item|
       song_item.update_author_from_spotify!(spotify_token)
     end
-    update!(status: 'completed') if (song_items.completed.count == song_items.count)
+    update!(status: 'completed') if song_items.completed.count == song_items.count
   end
 
   def self.update_songs_author_from_spotify!

--- a/backend/app/models/concerns/song_live.rb
+++ b/backend/app/models/concerns/song_live.rb
@@ -31,7 +31,11 @@ module SongLive
 
       # SongItemsが見つかったらそこで終了
       if song_items.present?
-        update!(status: 'song_items_created')
+        if song_items.completed.count == song_items.count
+          update!(status: 'completed') 
+        else
+          update!(status: 'song_items_created')
+        end
         return song_items
       end
     end
@@ -60,7 +64,11 @@ module SongLive
 
         # SongItemsが見つかり次第終了
         if song_items.present?
-          update!(status: 'song_items_created')
+          if song_items.completed.count == song_items.count
+            update!(status: 'completed') 
+          else
+            update!(status: 'song_items_created')
+          end
           return song_items
         end
       end
@@ -85,6 +93,10 @@ module SongLive
   def self.update_songs_author_from_spotify!
     token = Spotify.get_token
     where(status: %w[song_items_created spotify_fetched]).each do |video|
+      if song_items.completed.count == song_items.count
+        update!(status: 'completed')
+        next
+      end
       video.update_author_from_spotify!(token)
     end
   end

--- a/backend/app/models/concerns/song_live.rb
+++ b/backend/app/models/concerns/song_live.rb
@@ -7,7 +7,8 @@ module SongLive
     end
 
     def search_and_create_song_items!
-      order(published_at: :desc).all.each(&:search_and_create_song_items!)
+      where.not(status: %w[song_items_created spotify_fetched completed])\
+        .order(published_at: :desc).all.each(&:search_and_create_song_items!)
     end
   end
 
@@ -30,7 +31,7 @@ module SongLive
 
       # SongItemsが見つかったらそこで終了
       if song_items.present?
-        update!(status: 'completed')
+        update!(status: 'song_items_created')
         return song_items
       end
     end
@@ -59,7 +60,7 @@ module SongLive
 
         # SongItemsが見つかり次第終了
         if song_items.present?
-          update!(status: 'completed')
+          update!(status: 'song_items_created')
           return song_items
         end
       end

--- a/backend/app/models/concerns/song_live.rb
+++ b/backend/app/models/concerns/song_live.rb
@@ -75,11 +75,11 @@ module SongLive
 
   def update_songs_author_from_spotify!(spotify_token=nil)
     spotify_token ||= Spotify.get_token
-    video.update!(status: 'spotify_fetched')
-    where(latest_diff_id: SongDiff.where(author: [nil, ""])).each do |song_item|
+    update!(status: 'spotify_fetched')
+    song_items.where(latest_diff_id: SongDiff.where(author: [nil, ""])).each do |song_item|
       song_item.update_author_from_spotify!(spotify_token)
     end
-    update!(status: 'completed') if (video.song_items.completed.count == video.song_items.count)
+    update!(status: 'completed') if (song_items.completed.count == song_items.count)
   end
 
   def self.update_songs_author_from_spotify!

--- a/backend/app/models/concerns/spotify.rb
+++ b/backend/app/models/concerns/spotify.rb
@@ -3,7 +3,7 @@ require 'net/http'
 module Spotify
   TOKEN_ENDPOINT = 'https://accounts.spotify.com/api/token'
   def self.get_token
-    uri = URI(TOKEN_ENDPOINT)
+    uri = URI.parse(TOKEN_ENDPOINT)
     data = {
       grant_type: 'client_credentials',
       client_id: ENV.fetch('SPOTIFY_CLIENT_ID'),
@@ -12,5 +12,22 @@ module Spotify
     response = Net::HTTP.post_form(uri, data)
     json = JSON.parse(response.body)
     json['access_token']
+  end
+
+  SEARCH_ENDPOINT = 'https://api.spotify.com/v1/search'
+  def self.get_songs_data(title, limit=1, token=nil)
+    token ||= get_token
+    uri = URI.parse(SEARCH_ENDPOINT)
+    uri.query = URI.encode_www_form({
+      q: "track:#{title}",
+      limit: limit.to_s,
+      type: 'track'
+    })
+    headers = {
+      Authorization: "Bearer #{token}"
+    }
+    response = Net::HTTP.get_response(uri, headers)
+    json = JSON.parse(response.body)
+    json.dig('tracks', 'items')
   end
 end

--- a/backend/app/models/concerns/spotify.rb
+++ b/backend/app/models/concerns/spotify.rb
@@ -15,7 +15,7 @@ module Spotify
   end
 
   SEARCH_ENDPOINT = 'https://api.spotify.com/v1/search'
-  def self.get_songs_data(title, limit=1, token=nil)
+  def self.get_songs_data(title, limit:1, token:nil)
     token ||= get_token
     uri = URI.parse(SEARCH_ENDPOINT)
     uri.query = URI.encode_www_form({
@@ -26,6 +26,19 @@ module Spotify
     headers = {
       Authorization: "Bearer #{token}"
     }
+    response = Net::HTTP.get_response(uri, headers)
+    json = JSON.parse(response.body)
+    items = json.dig('tracks', 'items')
+
+    return items if items.present?
+
+    # itemsが空の場合はクエリからtrack:の文字を消して再度リクエストする
+    uri = URI.parse(SEARCH_ENDPOINT)
+    uri.query = URI.encode_www_form({
+      q: title,
+      limit: limit.to_s,
+      type: 'track'
+    })
     response = Net::HTTP.get_response(uri, headers)
     json = JSON.parse(response.body)
     json.dig('tracks', 'items')

--- a/backend/app/models/concerns/spotify.rb
+++ b/backend/app/models/concerns/spotify.rb
@@ -1,0 +1,16 @@
+require 'net/http'
+
+module Spotify
+  TOKEN_ENDPOINT = 'https://accounts.spotify.com/api/token'
+  def self.get_token
+    uri = URI(TOKEN_ENDPOINT)
+    data = {
+      grant_type: 'client_credentials',
+      client_id: ENV.fetch('SPOTIFY_CLIENT_ID'),
+      client_secret: ENV.fetch('SPOTIFY_CLIENT_SECRET')
+    }
+    response = Net::HTTP.post_form(uri, data)
+    json = JSON.parse(response.body)
+    json['access_token']
+  end
+end

--- a/backend/app/models/concerns/spotify.rb
+++ b/backend/app/models/concerns/spotify.rb
@@ -1,7 +1,7 @@
 require 'net/http'
 
 module Spotify
-  TOKEN_ENDPOINT = 'https://accounts.spotify.com/api/token'
+  TOKEN_ENDPOINT = 'https://accounts.spotify.com/api/token'.freeze
   def self.get_token
     uri = URI.parse(TOKEN_ENDPOINT)
     data = {
@@ -14,8 +14,8 @@ module Spotify
     json['access_token']
   end
 
-  SEARCH_ENDPOINT = 'https://api.spotify.com/v1/search'
-  def self.get_songs_data(title, token:nil)
+  SEARCH_ENDPOINT = 'https://api.spotify.com/v1/search'.freeze
+  def self.get_songs_data(title, token: nil)
     token ||= get_token
     headers = {
       Authorization: "Bearer #{token}"
@@ -24,26 +24,26 @@ module Spotify
     # クエリにtrack:を含む場合と含まない場合それぞれで
     uri = URI.parse(SEARCH_ENDPOINT)
     uri.query = URI.encode_www_form({
-      q: "track:#{title}",
-      limit: '1',
-      type: 'track',
-      market: 'JP'
-    })
+                                      q: "track:#{title}",
+                                      limit: '1',
+                                      type: 'track',
+                                      market: 'JP'
+                                    })
     response = Net::HTTP.get_response(uri, headers)
     json = JSON.parse(response.body)
     item1 = json.dig('tracks', 'items')&.first
 
     uri = URI.parse(SEARCH_ENDPOINT)
     uri.query = URI.encode_www_form({
-      q: title,
-      limit: '1',
-      type: 'track',
-      market: 'JP'
-    })
+                                      q: title,
+                                      limit: '1',
+                                      type: 'track',
+                                      market: 'JP'
+                                    })
     response = Net::HTTP.get_response(uri, headers)
     json = JSON.parse(response.body)
     item2 = json.dig('tracks', 'items')&.first
-    
-    item2&.dig('popularity') < item1&.dig('popularity') ? item1 : item2
+
+    item2&.dig('popularity')&.< item1&.dig('popularity') ? item1 : item2
   end
 end

--- a/backend/app/models/song_item.rb
+++ b/backend/app/models/song_item.rb
@@ -32,16 +32,16 @@ class SongItem < ApplicationRecord
 
   def self.completed
     where(latest_diff_id:
-      SongDiff.where.not(title: ['', nil]).where.not(author: ['', nil]).where.not(time: ['', nil])
-    )
+      SongDiff.where.not(title: ['', nil]).where.not(author: ['', nil]).where.not(time: ['', nil]))
   end
 
-  def update_author_from_spotify!(spotify_token=nil)
+  def update_author_from_spotify!(spotify_token = nil)
     return self if title.blank?
 
     song_data = Spotify.get_songs_data(title, limit: 1, token: spotify_token).first
     return self if song_data.blank?
-    author = song_data.dig('artists').map{|data| data['name']}.join(', ')
+
+    author = song_data['artists'].pluck('name').join(', ')
 
     if latest_diff&.kind == 'auto'
       latest_diff.update!(author:)

--- a/backend/app/models/song_item.rb
+++ b/backend/app/models/song_item.rb
@@ -26,6 +26,16 @@ class SongItem < ApplicationRecord
     latest_diff&.time
   end
 
+  def completed?
+    title.present? && author.present? && time.present?
+  end
+
+  def self.completed
+    where(latest_diff_id:
+      SongDiff.where.not(title: ['', nil]).where.not(author: ['', nil]).where.not(time: ['', nil])
+    )
+  end
+
   def update_author_from_spotify!(spotify_token=nil)
     return self if title.blank?
 

--- a/backend/app/models/song_item.rb
+++ b/backend/app/models/song_item.rb
@@ -103,11 +103,4 @@ class SongItem < ApplicationRecord
     end
     song_items
   end
-
-  def self.update_author_from_spotify!(spotify_token=nil)
-    spotify_token ||= Spotify.get_token
-    where(latest_diff_id: SongDiff.where(author: [nil, ""])).each do |song_item|
-      song_item.update_author_from_spotify!(spotify_token)
-    end
-  end
 end

--- a/backend/app/models/song_item.rb
+++ b/backend/app/models/song_item.rb
@@ -27,7 +27,6 @@ class SongItem < ApplicationRecord
   end
 
   def update_author_from_spotify!(spotify_token=nil)
-    return self if author.present?
     return self if title.blank?
 
     song_data = Spotify.get_songs_data(title, limit: 1, token: spotify_token).first
@@ -93,5 +92,12 @@ class SongItem < ApplicationRecord
       song_items.push(song_item)
     end
     song_items
+  end
+
+  def self.update_author_from_spotify!(spotify_token=nil)
+    spotify_token ||= Spotify.get_token
+    where(latest_diff_id: SongDiff.where(author: [nil, ""])).each do |song_item|
+      song_item.update_author_from_spotify!(spotify_token)
+    end
   end
 end

--- a/backend/app/models/video.rb
+++ b/backend/app/models/video.rb
@@ -17,7 +17,9 @@ class Video < ApplicationRecord
   enum status: {
     ready: 0,
     fetched: 10,
-    completed: 20
+    song_items_created: 20,
+    spotify_fetched: 30,
+    completed: 40
   }, _prefix: true
 
   def self.fetch_and_create!(video_ids)

--- a/backend/app/views/admin/videos/song_diffs/_form.html.haml
+++ b/backend/app/views/admin/videos/song_diffs/_form.html.haml
@@ -14,7 +14,7 @@
     .col-md-9= form.collection_select :made_by_id, User.all, :id, :name, { include_blank: true }, class: 'form-control'
   .row.mb-3
     .col-md-3.col-form-label.fw-bold 開始時間
-    .col-md-9= form.time_field :time, class: 'form-control', step: 1
+    .col-md-9= form.text_field :time, class: 'form-control', step: 1
   .row.mb-3
     .col-md-3.col-form-label.fw-bold タイトル
     .col-md-9= form.text_field :title, class: 'form-control'

--- a/backend/lib/tasks/videos.rake
+++ b/backend/lib/tasks/videos.rake
@@ -4,7 +4,7 @@ namespace :videos do
     p 'Start searching recent videos'
     Channel.all.each(&:search_and_create_recent_videos)
     p 'Start searching setlist'
-    Video.where.not(status: 'completed').search_and_create_song_items!
+    Video.search_and_create_song_items!
     p 'Completed searching setlist'
   end
 end


### PR DESCRIPTION
fix: #149 
精度が意外と高くなかったから、歌手名が空白の場合は基本的に過去のデータを参考に判断する方針にする